### PR TITLE
#50031: coverage test status labels controller

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -891,7 +891,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:'.config('app.
                 ]
             )->name('api.statuslabels.assets.bytype');
 
-            Route::get('assetlist',
+            Route::get('{id}/assetlist',
                 [
                     Api\StatuslabelsController::class, 
                     'assets'


### PR DESCRIPTION
- Task 50031: https://ops.nccsoft.vn/DefaultCollection/NCC-ITTools/_workitems/edit/50031
- Update ApiStatusLabelsCest
- Update missing id in status labels api


- Evidence: https://drive.google.com/file/d/1oTRhJtam57hdNW7VX0ucwY6TEuq1tNGN/view?usp=sharing